### PR TITLE
check for binary uuid

### DIFF
--- a/src/MetaModels/Attribute/TranslatedFile/TranslatedFile.php
+++ b/src/MetaModels/Attribute/TranslatedFile/TranslatedFile.php
@@ -126,7 +126,7 @@ class TranslatedFile extends TranslatedReference
             // Set root path of file chooser depending on contao version.
             $objFile = null;
 
-            if (\Validator::isStringUuid($this->get('file_uploadFolder'))) {
+            if (\Validator::isStringUuid($this->get('file_uploadFolder')) || \Validator::isBinaryUuid($this->get('file_uploadFolder'))) {
                 $objFile = \FilesModel::findByUuid($this->get('file_uploadFolder'));
             }
 


### PR DESCRIPTION
also check for isBinaryUuid cause it leads to problems and \FilesModel::findByUuid() can handle string and binary

If a path with a real binary uuid is given it leads to a path not found and an empty file list